### PR TITLE
API Tweaks

### DIFF
--- a/teensy/avr/cores/teensy3/usb_xinput.c
+++ b/teensy/avr/cores/teensy3/usb_xinput.c
@@ -42,8 +42,19 @@ bool usb_xinput_connected(void)
 	return usb_configuration;
 }
 
-//Function receives packets from the RX endpoint
-//We will use this for receiving LED commands
+// Function to check if packets are available
+// to be received on the RX endpoint
+int usb_xinput_available(void)
+{
+	uint32_t count;
+
+	if (!usb_configuration) return 0;
+	count = usb_rx_byte_count(XINPUT_RX_ENDPOINT);
+	return count;
+}
+
+
+// Function receives packets from the RX endpoint
 int usb_xinput_recv(void *buffer, uint8_t nbytes)
 {
 	usb_packet_t *rx_packet;
@@ -61,22 +72,11 @@ int usb_xinput_recv(void *buffer, uint8_t nbytes)
 	return nbytes;
 }
 
-//Function to check if packets are available
-//to be received on the RX endpoint
-int usb_xinput_available(void)
-{
-	uint32_t count;
-
-	if (!usb_configuration) return 0;
-	count = usb_rx_byte_count(XINPUT_RX_ENDPOINT);
-	return count;
-}
-
 // Maximum number of transmit packets to queue so we don't starve other endpoints for memory
 #define TX_PACKET_LIMIT 3
 
-//Function used to send packets out of the TX endpoint
-//This is used to send button reports
+// Function used to send packets out of the TX endpoint
+// This is used to send button reports
 int usb_xinput_send(const void *buffer, uint8_t nbytes)
 {
 	usb_packet_t *tx_packet;

--- a/teensy/avr/cores/teensy3/usb_xinput.h
+++ b/teensy/avr/cores/teensy3/usb_xinput.h
@@ -37,8 +37,8 @@
 extern "C" {
 #endif
 bool usb_xinput_connected(void);
-int  usb_xinput_recv(void *buffer, uint8_t nbytes);
 int  usb_xinput_available(void);
+int  usb_xinput_recv(void *buffer, uint8_t nbytes);
 int  usb_xinput_send(const void *buffer, uint8_t nbytes);
 extern void (*usb_xinput_recv_callback)(void);
 #ifdef __cplusplus


### PR DESCRIPTION
A couple of small tweaks to how the USB API functions:

* Switched USB return types back to `int`. Using `size_t` makes sense but it gets rid of the distinction between `-1` and `0`, or whether there is no data vs whether there is an error. Going back to `int` to keep this distinction.

* Removes the USB timeout from the API. This is a lower level USB function and should be handled by the board implementation. `timeout` is now scoped to the source file and set to 250 ms, which should be more than long enough.

* The array size is now passed to send/receive functions. This is more idiomatic than just assuming that the array is of the proper size.

* The `available` function is now listed before the `recv` function in the C portion of the header and in the source file. Just because it makes more sense to me - there should be no functional change.