### PR TITLE
Unsigned 'available' API

### DIFF
--- a/teensy/avr/cores/teensy3/usb_xinput.c
+++ b/teensy/avr/cores/teensy3/usb_xinput.c
@@ -44,9 +44,9 @@ bool usb_xinput_connected(void)
 
 // Function to check if packets are available
 // to be received on the RX endpoint
-int usb_xinput_available(void)
+uint16_t usb_xinput_available(void)
 {
-	uint32_t count;
+	uint16_t count;
 
 	if (!usb_configuration) return 0;
 	count = usb_rx_byte_count(XINPUT_RX_ENDPOINT);

--- a/teensy/avr/cores/teensy3/usb_xinput.h
+++ b/teensy/avr/cores/teensy3/usb_xinput.h
@@ -37,9 +37,9 @@
 extern "C" {
 #endif
 bool usb_xinput_connected(void);
-int  usb_xinput_available(void);
-int  usb_xinput_send(const void *buffer, uint8_t nbytes);
-int  usb_xinput_recv(void *buffer, uint8_t nbytes);
+uint16_t usb_xinput_available(void);
+int usb_xinput_send(const void *buffer, uint8_t nbytes);
+int usb_xinput_recv(void *buffer, uint8_t nbytes);
 extern void (*usb_xinput_recv_callback)(void);
 #ifdef __cplusplus
 }
@@ -52,9 +52,9 @@ class XInputUSB
 {
 public:
 	static bool connected(void) { return usb_xinput_connected(); }
-	static int  available(void) { return usb_xinput_available(); }
-	static int  send(const void *buffer, uint8_t nbytes) { return usb_xinput_send(buffer, nbytes); }
-	static int  recv(void *buffer, uint8_t nbytes) { return usb_xinput_recv(buffer, nbytes); }
+	static uint16_t available(void) { return usb_xinput_available(); }
+	static int send(const void *buffer, uint8_t nbytes) { return usb_xinput_send(buffer, nbytes); }
+	static int recv(void *buffer, uint8_t nbytes) { return usb_xinput_recv(buffer, nbytes); }
 	static void setRecvCallback(void (*callback)(void)) { usb_xinput_recv_callback = callback; }
 };
 


### PR DESCRIPTION
Changes the 'available' function to return an unsigned integer rather than an 'int', because the function never throws an error (-1) and the number of bytes available will never be negative. Using `uint16_t` to match the return value for the Teensy USB stack.

Since I was already tweaking the API files, I also re-ordered the header so that the 'send' function was below the 'recv' function. This groups the two 'recv' functions together, and matches the typical order you talk about the functions (send/recv).