### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,71 @@
+language: C
+env:
+  global:
+    - IDE_VERSION=1.8.1
+    - TEENSY_VERSION=145
+    - IDE_LOCATION=/usr/local/share/arduino
+    - BOARDS_DESTINATION=$IDE_LOCATION/hardware
+
+matrix:
+  include:
+    - name: "Serial: Blank Sketch"
+      env: SKETCH="$IDE_LOCATION/examples/01.Basics/BareMinimum/BareMinimum.ino" USB_MODE=serial
+    - name: "XInput: Blank Sketch"
+      env: SKETCH="$IDE_LOCATION/examples/01.Basics/BareMinimum/BareMinimum.ino" USB_MODE=xinput
+    - name: "USB API Demo"
+      env: SKETCH="$IDE_LOCATION/libraries/ArduinoXInput/extras/API-Demo/API-Demo.ino" USB_MODE=xinput
+    - name: "XInput Library"
+      env: SKETCH="$IDE_LOCATION/libraries/ArduinoXInput/examples/GamepadPins/GamepadPins.ino" USB_MODE=xinput
+
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
+  - sleep 3
+  - export DISPLAY=:1.0
+
+  # Install Arduino IDE
+  - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
+  - tar xf arduino-$IDE_VERSION-linux64.tar.xz
+  - sudo mv arduino-$IDE_VERSION $IDE_LOCATION
+  - sudo ln -s $IDE_LOCATION/arduino /usr/local/bin/arduino
+  - rm arduino-$IDE_VERSION-linux64.tar.xz
+
+  # Install Teensyduino
+  - wget https://www.pjrc.com/teensy/td_$TEENSY_VERSION/TeensyduinoInstall.linux64
+  - chmod +x ./TeensyduinoInstall.linux64
+  - sudo ./TeensyduinoInstall.linux64 --dir=$IDE_LOCATION
+  - rm ./TeensyduinoInstall.linux64
+  
+  # Install XInput Library
+  - if [[ $SKETCH == *"ArduinoXInput"* ]]; then
+      git clone https://github.com/dmadison/ArduinoXInput.git;
+      mv ArduinoXInput $IDE_LOCATION/libraries;
+    fi
+
+  # Sketch Compiling Functions
+  - CYAN="\033[36m"; NOC="\033[0m";
+  - buildSketch() {
+      echo -e "\n${CYAN}Building sketch ${SKETCH##*/} for $BOARD${NOC}";
+      arduino --verify --board $BOARD "$SKETCH";
+    }
+
+install:
+  - sudo \cp -r teensy $BOARDS_DESTINATION;
+
+script:
+  # Teensy 3.6
+  - BOARD=teensy:avr:teensy36:usb=$USB_MODE,speed=180,opt=o2std,keys=en-us; buildSketch;
+  
+  # Teensy 3.5
+  - BOARD=teensy:avr:teensy35:usb=$USB_MODE,speed=120,opt=o2std,keys=en-us; buildSketch;
+  
+  # Teensy 3.1/ 3.2
+  - BOARD=teensy:avr:teensy31:usb=$USB_MODE,speed=72,opt=o2std,keys=en-us; buildSketch;
+  
+  # Teensy LC
+  - BOARD=teensy:avr:teensyLC:usb=$USB_MODE,speed=48,opt=o2std,keys=en-us; buildSketch;
+
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Teensy XInput USB Mode
+# Teensy XInput USB Mode [![Build Status](https://travis-ci.org/dmadison/ArduinoXInput_Teensy.svg?branch=master)](https://travis-ci.org/dmadison/ArduinoXInput_Teensy)
 
 The files in this repository will add an additional USB mode ("XInput") to your Teensy 3 board, allowing it to emulate an Xbox gamepad.
 


### PR DESCRIPTION
Adds Travis CI support, checking all supported boards with four sketches: 

* Serial Blank Sketch (did I break the other USB modes?)
* XInput Blank Sketch (does it compile?)
* USB API Demo (are the API functions present and compiling?)
* XInput Library "GamepadPins" example (does the library work?)

Should provide reasonable coverage that all boards are compiling correctly. Although it doesn't tell me anything about the resultant USB functionality.