### PR TITLE
Teensyduino 1.50 Compatibility 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: C
 env:
   global:
-    - IDE_VERSION=1.8.10
-    - TEENSY_VERSION=149
+    - IDE_VERSION=1.8.11
+    - TEENSY_VERSION=150
     - IDE_LOCATION=/usr/local/share/arduino
     - BOARDS_DESTINATION=$IDE_LOCATION/hardware
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is meant to be used in conjunction with the [ArduinoXInput library](https:/
  
 ## Installation
 
-You must have both [Arduino](https://www.arduino.cc/en/main/software) and [Teensyduino](https://www.pjrc.com/teensy/td_download.html) installed before proceeding. Double-check that your installed Teensyduino version matches the files provided in this repository. This repository is currently using version [**1.49**](https://www.pjrc.com/teensy/td_149). If you don't know your Teensyduino version, compile a blank sketch with a Teensy board selected and the Teensy Loader will open. In the Teensy Loader window select `Help -> About` and it will tell you the version number. If your version does not match you will have to reinstall or update the Teensyduino software.
+You must have both [Arduino](https://www.arduino.cc/en/main/software) and [Teensyduino](https://www.pjrc.com/teensy/td_download.html) installed before proceeding. Double-check that your installed Teensyduino version matches the files provided in this repository. This repository is currently using version [**1.50**](https://www.pjrc.com/teensy/td_150). If you don't know your Teensyduino version, compile a blank sketch with a Teensy board selected and the Teensy Loader will open. In the Teensy Loader window select `Help -> About` and it will tell you the version number. If your version does not match you will have to reinstall or update the Teensyduino software.
 
 Navigate to your Arduino installation directory and open up the 'hardware' folder. It is recommended that you make a backup of this folder before proceeding in case something goes wrong or if you want to revert the installation.
 

--- a/teensy/avr/boards.txt
+++ b/teensy/avr/boards.txt
@@ -3,6 +3,204 @@ menu.speed=CPU Speed
 menu.opt=Optimize
 menu.keys=Keyboard Layout
 
+
+
+
+#teensy41.name=Teensy 4.1
+#teensy41.upload.maximum_size=2031616
+#teensy41.upload.maximum_data_size=524288
+##teensy41.upload.maximum_data_size=1048576
+#teensy41.upload.tool=teensyloader
+#teensy41.upload.protocol=halfkay
+#teensy41.build.board=TEENSY41
+#teensy41.build.core=teensy4
+#teensy41.build.mcu=imxrt1062
+#teensy41.build.warn_data_percentage=99
+#teensy41.build.toolchain=arm/bin/
+#teensy41.build.command.gcc=arm-none-eabi-gcc
+#teensy41.build.command.g++=arm-none-eabi-g++
+#teensy41.build.command.ar=arm-none-eabi-gcc-ar
+#teensy41.build.command.objcopy=arm-none-eabi-objcopy
+#teensy41.build.command.objdump=arm-none-eabi-objdump
+#teensy41.build.command.linker=arm-none-eabi-gcc
+#teensy41.build.command.size=arm-none-eabi-size
+#teensy41.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
+#teensy41.build.flags.dep=-MMD
+#teensy41.build.flags.optimize=-Os
+#teensy41.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
+#teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=150
+#teensy41.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
+#teensy41.build.flags.c=
+#teensy41.build.flags.S=-x assembler-with-cpp
+#teensy41.build.flags.ld=-Wl,--gc-sections,--relax "-T{build.core.path}/imxrt1062_t41.ld"
+#teensy41.build.flags.libs=-larm_cortexM7lfsp_math -lm -lstdc++
+#teensy41.serial.restart_cmd=false
+#teensy41.menu.usb.serial=Serial
+#teensy41.menu.usb.serial.build.usbtype=USB_SERIAL
+#teensy41.menu.usb.keyboard=Keyboard
+#teensy41.menu.usb.keyboard.build.usbtype=USB_KEYBOARDONLY
+#teensy41.menu.usb.keyboard.fake_serial=teensy_gateway
+#teensy41.menu.usb.touch=Keyboard + Touch Screen
+#teensy41.menu.usb.touch.build.usbtype=USB_TOUCHSCREEN
+#teensy41.menu.usb.touch.fake_serial=teensy_gateway
+#teensy41.menu.usb.hidtouch=Keyboard + Mouse + Touch Screen
+#teensy41.menu.usb.hidtouch.build.usbtype=USB_HID_TOUCHSCREEN
+#teensy41.menu.usb.hidtouch.fake_serial=teensy_gateway
+#teensy41.menu.usb.hid=Keyboard + Mouse + Joystick
+#teensy41.menu.usb.hid.build.usbtype=USB_HID
+#teensy41.menu.usb.hid.fake_serial=teensy_gateway
+#teensy41.menu.usb.serialhid=Serial + Keyboard + Mouse + Joystick
+#teensy41.menu.usb.serialhid.build.usbtype=USB_SERIAL_HID
+#teensy41.menu.usb.midi=MIDI
+#teensy41.menu.usb.midi.build.usbtype=USB_MIDI
+#teensy41.menu.usb.midi.fake_serial=teensy_gateway
+#teensy41.menu.usb.midi4=MIDIx4
+#teensy41.menu.usb.midi4.build.usbtype=USB_MIDI4
+#teensy41.menu.usb.midi4.fake_serial=teensy_gateway
+#teensy41.menu.usb.midi16=MIDIx16
+#teensy41.menu.usb.midi16.build.usbtype=USB_MIDI16
+#teensy41.menu.usb.midi16.fake_serial=teensy_gateway
+#teensy41.menu.usb.serialmidi=Serial + MIDI
+#teensy41.menu.usb.serialmidi.build.usbtype=USB_MIDI_SERIAL
+#teensy41.menu.usb.serialmidi4=Serial + MIDIx4
+#teensy41.menu.usb.serialmidi4.build.usbtype=USB_MIDI4_SERIAL
+#teensy41.menu.usb.serialmidi16=Serial + MIDIx16
+#teensy41.menu.usb.serialmidi16.build.usbtype=USB_MIDI16_SERIAL
+##teensy41.menu.usb.audio=Audio
+##teensy41.menu.usb.audio.build.usbtype=USB_AUDIO
+##teensy41.menu.usb.audio.fake_serial=teensy_gateway
+##teensy41.menu.usb.serialmidiaudio=Serial + MIDI + Audio
+##teensy41.menu.usb.serialmidiaudio.build.usbtype=USB_MIDI_AUDIO_SERIAL
+##teensy41.menu.usb.serialmidi16audio=Serial + MIDIx16 + Audio
+##teensy41.menu.usb.serialmidi16audio.build.usbtype=USB_MIDI16_AUDIO_SERIAL
+##teensy41.menu.usb.mtp=MTP Disk (Experimental)
+##teensy41.menu.usb.mtp.build.usbtype=USB_MTPDISK
+##teensy41.menu.usb.mtp.fake_serial=teensy_gateway
+#teensy41.menu.usb.rawhid=Raw HID
+#teensy41.menu.usb.rawhid.build.usbtype=USB_RAWHID
+#teensy41.menu.usb.rawhid.fake_serial=teensy_gateway
+##teensy41.menu.usb.flightsim=Flight Sim Controls
+##teensy41.menu.usb.flightsim.build.usbtype=USB_FLIGHTSIM
+##teensy41.menu.usb.flightsim.fake_serial=teensy_gateway
+##teensy41.menu.usb.flightsimjoystick=Flight Sim Controls + Joystick
+##teensy41.menu.usb.flightsimjoystick.build.usbtype=USB_FLIGHTSIM_JOYSTICK
+##teensy41.menu.usb.flightsimjoystick.fake_serial=teensy_gateway
+##teensy41.menu.usb.disable=No USB
+##teensy41.menu.usb.disable.build.usbtype=USB_DISABLED
+#
+#teensy41.menu.speed.600=600 MHz
+#teensy41.menu.speed.528=528 MHz
+#teensy41.menu.speed.450=450 MHz
+#teensy41.menu.speed.396=396 MHz
+#teensy41.menu.speed.150=150 MHz
+#teensy41.menu.speed.24=24 MHz
+#teensy41.menu.speed.720=720 MHz (overclock)
+#teensy41.menu.speed.816=816 MHz (overclock)
+#teensy41.menu.speed.912=912 MHz (overclock, cooling req'd)
+#teensy41.menu.speed.960=960 MHz (overclock, cooling req'd)
+#teensy41.menu.speed.1008=1.008 GHz (overclock, cooling req'd)
+#teensy41.menu.speed.1008.build.fcpu=1008000000
+#teensy41.menu.speed.960.build.fcpu=960000000
+#teensy41.menu.speed.912.build.fcpu=912000000
+#teensy41.menu.speed.816.build.fcpu=816000000
+#teensy41.menu.speed.720.build.fcpu=720000000
+#teensy41.menu.speed.600.build.fcpu=600000000
+#teensy41.menu.speed.528.build.fcpu=528000000
+#teensy41.menu.speed.450.build.fcpu=450000000
+#teensy41.menu.speed.396.build.fcpu=396000000
+#teensy41.menu.speed.150.build.fcpu=150000000
+#teensy41.menu.speed.24.build.fcpu=24000000
+#
+#teensy41.menu.opt.o2std=Faster
+#teensy41.menu.opt.o2std.build.flags.optimize=-O2
+#teensy41.menu.opt.o2std.build.flags.ldspecs=
+##teensy41.menu.opt.o2lto=Faster with LTO
+##teensy41.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
+##teensy41.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
+#teensy41.menu.opt.o1std=Fast
+#teensy41.menu.opt.o1std.build.flags.optimize=-O1
+#teensy41.menu.opt.o1std.build.flags.ldspecs=
+##teensy41.menu.opt.o1lto=Fast with LTO
+##teensy41.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
+##teensy41.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
+#teensy41.menu.opt.o3std=Fastest
+#teensy41.menu.opt.o3std.build.flags.optimize=-O3
+#teensy41.menu.opt.o3std.build.flags.ldspecs=
+##teensy41.menu.opt.o3purestd=Fastest + pure-code
+##teensy41.menu.opt.o3purestd.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__
+##teensy41.menu.opt.o3purestd.build.flags.ldspecs=
+##teensy41.menu.opt.o3lto=Fastest with LTO
+##teensy41.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
+##teensy41.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
+##teensy41.menu.opt.o3purelto=Fastest + pure-code with LTO
+##teensy41.menu.opt.o3purelto.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__ -flto -fno-fat-lto-objects
+##teensy41.menu.opt.o3purelto.build.flags.ldspecs=-fuse-linker-plugin
+#teensy41.menu.opt.ogstd=Debug
+#teensy41.menu.opt.ogstd.build.flags.optimize=-Og
+#teensy41.menu.opt.ogstd.build.flags.ldspecs=
+##teensy41.menu.opt.oglto=Debug with LTO
+##teensy41.menu.opt.oglto.build.flags.optimize=-Og -flto -fno-fat-lto-objects
+##teensy41.menu.opt.oglto.build.flags.ldspecs=-fuse-linker-plugin
+#teensy41.menu.opt.osstd=Smallest Code
+#teensy41.menu.opt.osstd.build.flags.optimize=-Os --specs=nano.specs
+#teensy41.menu.opt.osstd.build.flags.ldspecs=
+##teensy41.menu.opt.oslto=Smallest Code with LTO
+##teensy41.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
+##teensy41.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
+#
+#teensy41.menu.keys.en-us=US English
+#teensy41.menu.keys.en-us.build.keylayout=US_ENGLISH
+#teensy41.menu.keys.fr-ca=Canadian French
+#teensy41.menu.keys.fr-ca.build.keylayout=CANADIAN_FRENCH
+#teensy41.menu.keys.xx-ca=Canadian Multilingual
+#teensy41.menu.keys.xx-ca.build.keylayout=CANADIAN_MULTILINGUAL
+#teensy41.menu.keys.cz-cz=Czech
+#teensy41.menu.keys.cz-cz.build.keylayout=CZECH
+#teensy41.menu.keys.da-da=Danish
+#teensy41.menu.keys.da-da.build.keylayout=DANISH
+#teensy41.menu.keys.fi-fi=Finnish
+#teensy41.menu.keys.fi-fi.build.keylayout=FINNISH
+#teensy41.menu.keys.fr-fr=French
+#teensy41.menu.keys.fr-fr.build.keylayout=FRENCH
+#teensy41.menu.keys.fr-be=French Belgian
+#teensy41.menu.keys.fr-be.build.keylayout=FRENCH_BELGIAN
+#teensy41.menu.keys.fr-ch=French Swiss
+#teensy41.menu.keys.fr-ch.build.keylayout=FRENCH_SWISS
+#teensy41.menu.keys.de-de=German
+#teensy41.menu.keys.de-de.build.keylayout=GERMAN
+#teensy41.menu.keys.de-dm=German (Mac)
+#teensy41.menu.keys.de-dm.build.keylayout=GERMAN_MAC
+#teensy41.menu.keys.de-ch=German Swiss
+#teensy41.menu.keys.de-ch.build.keylayout=GERMAN_SWISS
+#teensy41.menu.keys.is-is=Icelandic
+#teensy41.menu.keys.is-is.build.keylayout=ICELANDIC
+#teensy41.menu.keys.en-ie=Irish
+#teensy41.menu.keys.en-ie.build.keylayout=IRISH
+#teensy41.menu.keys.it-it=Italian
+#teensy41.menu.keys.it-it.build.keylayout=ITALIAN
+#teensy41.menu.keys.no-no=Norwegian
+#teensy41.menu.keys.no-no.build.keylayout=NORWEGIAN
+#teensy41.menu.keys.pt-pt=Portuguese
+#teensy41.menu.keys.pt-pt.build.keylayout=PORTUGUESE
+#teensy41.menu.keys.pt-br=Portuguese Brazilian
+#teensy41.menu.keys.pt-br.build.keylayout=PORTUGUESE_BRAZILIAN
+#teensy41.menu.keys.rs-rs=Serbian (Latin Only)
+#teensy41.menu.keys.rs-rs.build.keylayout=SERBIAN_LATIN_ONLY
+#teensy41.menu.keys.es-es=Spanish
+#teensy41.menu.keys.es-es.build.keylayout=SPANISH
+#teensy41.menu.keys.es-mx=Spanish Latin America
+#teensy41.menu.keys.es-mx.build.keylayout=SPANISH_LATIN_AMERICA
+#teensy41.menu.keys.sv-se=Swedish
+#teensy41.menu.keys.sv-se.build.keylayout=SWEDISH
+#teensy41.menu.keys.tr-tr=Turkish (partial)
+#teensy41.menu.keys.tr-tr.build.keylayout=TURKISH
+#teensy41.menu.keys.en-gb=United Kingdom
+#teensy41.menu.keys.en-gb.build.keylayout=UNITED_KINGDOM
+#teensy41.menu.keys.usint=US International
+#teensy41.menu.keys.usint.build.keylayout=US_INTERNATIONAL
+
+
+
 teensy40.name=Teensy 4.0
 teensy40.upload.maximum_size=2031616
 teensy40.upload.maximum_data_size=524288
@@ -25,7 +223,7 @@ teensy40.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy40.build.flags.dep=-MMD
 teensy40.build.flags.optimize=-Os
 teensy40.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=149
+teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=150
 teensy40.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy40.build.flags.c=
 teensy40.build.flags.S=-x assembler-with-cpp
@@ -96,7 +294,7 @@ teensy40.menu.speed.816=816 MHz (overclock)
 teensy40.menu.speed.912=912 MHz (overclock, cooling req'd)
 teensy40.menu.speed.960=960 MHz (overclock, cooling req'd)
 teensy40.menu.speed.1008=1.008 GHz (overclock, cooling req'd)
-teensy40.menu.speed.1008.build.fcpu=1000000000
+teensy40.menu.speed.1008.build.fcpu=1008000000
 teensy40.menu.speed.960.build.fcpu=960000000
 teensy40.menu.speed.912.build.fcpu=912000000
 teensy40.menu.speed.816.build.fcpu=816000000
@@ -218,7 +416,7 @@ teensy36.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy36.build.flags.dep=-MMD
 teensy36.build.flags.optimize=-Os
 teensy36.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=149
+teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=150
 teensy36.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy36.build.flags.c=
 teensy36.build.flags.S=-x assembler-with-cpp
@@ -426,7 +624,7 @@ teensy35.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy35.build.flags.dep=-MMD
 teensy35.build.flags.optimize=-Os
 teensy35.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=149
+teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=150
 teensy35.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy35.build.flags.c=
 teensy35.build.flags.S=-x assembler-with-cpp
@@ -608,7 +806,7 @@ teensy31.upload.maximum_size=262144
 teensy31.upload.maximum_data_size=65536
 teensy31.upload.tool=teensyloader
 teensy31.upload.protocol=halfkay
-teensy31.build.board=TEENSY31
+teensy31.build.board=TEENSY32
 teensy31.build.core=teensy3
 teensy31.build.mcu=mk20dx256
 teensy31.build.warn_data_percentage=97
@@ -624,7 +822,7 @@ teensy31.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy31.build.flags.dep=-MMD
 teensy31.build.flags.optimize=-Os
 teensy31.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=149
+teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=150
 teensy31.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy31.build.flags.c=
 teensy31.build.flags.S=-x assembler-with-cpp
@@ -833,7 +1031,7 @@ teensy30.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy30.build.flags.dep=-MMD
 teensy30.build.flags.optimize=-Os
 teensy30.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=149
+teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=150
 teensy30.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensy30.build.flags.c=
 teensy30.build.flags.S=-x assembler-with-cpp
@@ -992,7 +1190,7 @@ teensyLC.build.command.size=arm-none-eabi-size
 teensyLC.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib
 teensyLC.build.flags.dep=-MMD
 teensyLC.build.flags.cpu=-mthumb -mcpu=cortex-m0plus -fsingle-precision-constant
-teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=149
+teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=150
 teensyLC.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
 teensyLC.build.flags.c=
 teensyLC.build.flags.S=-x assembler-with-cpp
@@ -1146,7 +1344,7 @@ teensypp2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensypp2.build.flags.dep=-MMD
 teensypp2.build.flags.optimize=-Os
 teensypp2.build.flags.cpu=-mmcu=at90usb1286
-teensypp2.build.flags.defs=-DTEENSYDUINO=149 -DARDUINO_ARCH_AVR
+teensypp2.build.flags.defs=-DTEENSYDUINO=150 -DARDUINO_ARCH_AVR
 teensypp2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensypp2.build.flags.c=
 teensypp2.build.flags.S=-x assembler-with-cpp
@@ -1263,7 +1461,7 @@ teensy2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensy2.build.flags.dep=-MMD
 teensy2.build.flags.optimize=-Os
 teensy2.build.flags.cpu=-mmcu=atmega32u4
-teensy2.build.flags.defs=-DTEENSYDUINO=149 -DARDUINO_ARCH_AVR
+teensy2.build.flags.defs=-DTEENSYDUINO=150 -DARDUINO_ARCH_AVR
 teensy2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensy2.build.flags.c=
 teensy2.build.flags.S=-x assembler-with-cpp


### PR DESCRIPTION
Updates `boards.txt` with changes introduced in version 1.50, updates travis.yml continuous integration to use Teensy 1.50 and Arduino 1.8.11, and updates the README to point to the new binaries.