### PR TITLE
Teensy 4 Support Fixup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,6 @@ jobs:
 
       - name: Teensy 4.1
         run: arduino --verify --board teensy:avr:teensy41:usb=${{ matrix.usb_mode }},speed=600,opt=o2std,keys=en-us ${{ matrix.sketch }};
+
+      - name: Teensy MicroMod
+        run: arduino --verify --board teensy:avr:teensyMM:usb=${{ matrix.usb_mode }},speed=600,opt=o2std,keys=en-us ${{ matrix.sketch }};

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ These board definitions make use of Microsoft's VID and PID in order to latch on
 
 A massive thank you to Zach Littell, whose did all of the original legwork in putting this together. Check out some of his stuff at [zlittell.com](http://www.zlittell.com).
 
+Another big thanks for Tom Mason ([@wheybags](https://github.com/wheybags)), who added support for the Teensy 4 boards ([#26](https://github.com/dmadison/ArduinoXInput_Teensy/pull/26)).
+
 ## License
 
 The original Teensy core files and their modified versions are licensed under a modified version of the permissive [MIT license](https://opensource.org/licenses/MIT). Newly contributed files are licensed under the MIT license with no additional stipulations.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To uninstall, restore your 'teensy' folder from a backup or reinstall Teensyduin
 * [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)
 * [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)
 * [Teensy 3.1](https://www.pjrc.com/store/teensy31.html) / [3.2](https://www.pjrc.com/store/teensy32.html)
-* [Teensy LC](https://www.pjrc.com/teensy/teensyLC.html)
+* [Teensy LC](https://www.pjrc.com/store/teensylc.html)
 * [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
 * [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teensy XInput USB Mode [![Build Status](https://github.com/dmadison/ArduinoXInput_Teensy/workflows/build/badge.svg?branch=master)](https://github.com/dmadison/ArduinoXInput_Teensy/actions?query=workflow%3Abuild)
 
-The files in this repository will add an additional USB mode ("XInput") to your Teensy 3 board, allowing it to emulate an Xbox gamepad.
+The files in this repository will add an additional USB mode ("XInput") to your Teensy board, allowing it to emulate an Xbox gamepad.
 
 This is meant to be used in conjunction with the [ArduinoXInput library](https://github.com/dmadison/ArduinoXInput).
  
@@ -20,8 +20,8 @@ To uninstall, restore your 'teensy' folder from a backup or reinstall Teensyduin
 * [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)
 * [Teensy 3.1](https://www.pjrc.com/store/teensy31.html) / [3.2](https://www.pjrc.com/store/teensy32.html)
 * [Teensy LC](https://www.pjrc.com/teensy/teensyLC.html)
+* [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
 * [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)
-  * Probably works on the [Teensy 4.0](https://www.pjrc.com/store/teensy40.html) as well, but untested!
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To uninstall, restore your 'teensy' folder from a backup or reinstall Teensyduin
 * [Teensy LC](https://www.pjrc.com/store/teensylc.html)
 * [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
 * [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)
+* [Teensy MicroMod](https://www.sparkfun.com/products/16402)
 
 ## Limitations
 

--- a/teensy/avr/boards.txt
+++ b/teensy/avr/boards.txt
@@ -298,6 +298,9 @@ teensyMM.menu.usb.flightsim.fake_serial=teensy_gateway
 teensyMM.menu.usb.flightsimjoystick=Flight Sim Controls + Joystick
 teensyMM.menu.usb.flightsimjoystick.build.usbtype=USB_FLIGHTSIM_JOYSTICK
 teensyMM.menu.usb.flightsimjoystick.fake_serial=teensy_gateway
+teensyMM.menu.usb.xinput=XInput
+teensyMM.menu.usb.xinput.build.usbtype=USB_XINPUT
+teensyMM.menu.usb.xinput.fake_serial=teensy_gateway
 #teensyMM.menu.usb.disable=No USB
 #teensyMM.menu.usb.disable.build.usbtype=USB_DISABLED
 

--- a/teensy/avr/cores/teensy4/usb.c
+++ b/teensy/avr/cores/teensy4/usb.c
@@ -822,6 +822,11 @@ static void endpoint0_complete(void)
 		usb_audio_set_feature(&endpoint0_setupdata, endpoint0_buffer);
 	}
 #endif
+#ifdef XINPUT_INTERFACE
+	// dummy reads to suppress '-Wunused-but-set-variable' and '-Wunused-variable' warnings from GCC
+	(void) setup.wIndex;
+	(void) endpoint0_buffer;
+#endif
 }
 
 static void usb_endpoint_config(endpoint_t *qh, uint32_t config, void (*callback)(transfer_t *))

--- a/teensy/avr/cores/teensy4/usb_xinput.c
+++ b/teensy/avr/cores/teensy4/usb_xinput.c
@@ -92,9 +92,6 @@ static void rx_event(transfer_t *t)
 
 void usb_xinput_configure()
 {
-  pinMode(LED_BUILTIN, OUTPUT);
-  digitalWrite(LED_BUILTIN, LOW);
-
   memset(tx_transfer, 0, sizeof(tx_transfer));
   tx_head = 0;
   usb_config_tx(XINPUT_TX_ENDPOINT, XINPUT_TX_SIZE, 0, NULL);
@@ -146,12 +143,6 @@ int usb_xinput_recv(void *buffer, uint8_t nbytes)
 
     uint8_t* p = rx_buffer + ii * XINPUT_RX_SIZE;
     memcpy(buffer, p, count);
-
-    if (count >= 5 && p[0] == 0x00)
-    {
-      int rumbling = (p[3] > 0 || p[4] > 0 );
-      digitalWrite(LED_BUILTIN, rumbling);
-    }
 
     rx_available -= rx_count[ii];
     rx_tail = tail;


### PR DESCRIPTION
A few miscellaneous changes to fix up the Teensy 4 support for release:

* Removed the rumble LED feature so that pin is still available to users
* Cleaned up Teensy 4 references in the README
* Added support for the Teensy MicroMod
* Suppressed GCC warnings from the endpoint0 function
