### PR TITLE
Teensyduino 1.59 Compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   IDE_VERSION: 1.8.19
-  TEENSY_VERSION: 158
+  TEENSY_VERSION: 159
   IDE_LOCATION: /usr/local/share/arduino
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         compilation: ['Serial: Blank Sketch', 'XInput: Blank Sketch', 'USB API Demo', 'XInput Library']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Arduino IDE
         run: |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is meant to be used in conjunction with the [ArduinoXInput library](https:/
 
 You must have both [the Arduino IDE](https://www.arduino.cc/en/main/software) and [Teensyduino](https://www.pjrc.com/teensy/td_download.html) installed before proceeding.
 
-Double-check that your installed Teensyduino version matches the files provided in this repository. This repository is currently using [**Teensyduino 1.58**](https://www.pjrc.com/teensy/td_158). You can download older versions on [the releases page](../../releases).
+Double-check that your installed Teensyduino version matches the files provided in this repository. This repository is currently using [**Teensyduino 1.59**](https://www.pjrc.com/teensy/td_159). You can download older versions on [the releases page](../../releases).
 
 If you don't know your Teensyduino version, compile a blank sketch with a Teensy board selected and the Teensy Loader will open. In the Teensy Loader window select `Help -> About` and it will tell you the version number. If your version does not match you will have to reinstall or update the Teensyduino software.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ For IDE version 2.x the Teensy hardware files are located in your application da
 
 Where `{version}` is the installed version number of the Teensyduino software.
 
+Version 2 of the IDE is reported to have issues with caching board files, which may prevent this project from loading or functioning properly. Consider using the version 1 IDE if you run into problems with installation.
+
 ## Supported Boards
 
 * [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)

--- a/teensy/avr/boards.txt
+++ b/teensy/avr/boards.txt
@@ -41,8 +41,8 @@ teensy41.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy41.build.flags.dep=-MMD
 teensy41.build.flags.optimize=-Os
 teensy41.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=158
-teensy41.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
+teensy41.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=159
+teensy41.build.flags.cpp=-std=gnu++17 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy41.build.flags.c=
 teensy41.build.flags.S=-x assembler-with-cpp
 teensy41.build.flags.libs=-larm_cortexM7lfsp_math -lm -lstdc++
@@ -157,24 +157,24 @@ teensy41.menu.speed.24.build.fcpu=24000000
 teensy41.menu.opt.o2std=Faster
 teensy41.menu.opt.o2std.build.flags.optimize=-O2
 teensy41.menu.opt.o2std.build.flags.ldspecs=
-#teensy41.menu.opt.o2lto=Faster with LTO
-#teensy41.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
-#teensy41.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
+teensy41.menu.opt.o2lto=Faster with LTO
+teensy41.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
+teensy41.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
 teensy41.menu.opt.o1std=Fast
 teensy41.menu.opt.o1std.build.flags.optimize=-O1
 teensy41.menu.opt.o1std.build.flags.ldspecs=
-#teensy41.menu.opt.o1lto=Fast with LTO
-#teensy41.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
-#teensy41.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
+teensy41.menu.opt.o1lto=Fast with LTO
+teensy41.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
+teensy41.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
 teensy41.menu.opt.o3std=Fastest
 teensy41.menu.opt.o3std.build.flags.optimize=-O3
 teensy41.menu.opt.o3std.build.flags.ldspecs=
 #teensy41.menu.opt.o3purestd=Fastest + pure-code
 #teensy41.menu.opt.o3purestd.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__
 #teensy41.menu.opt.o3purestd.build.flags.ldspecs=
-#teensy41.menu.opt.o3lto=Fastest with LTO
-#teensy41.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
-#teensy41.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
+teensy41.menu.opt.o3lto=Fastest with LTO
+teensy41.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
+teensy41.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
 #teensy41.menu.opt.o3purelto=Fastest + pure-code with LTO
 #teensy41.menu.opt.o3purelto.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__ -flto -fno-fat-lto-objects
 #teensy41.menu.opt.o3purelto.build.flags.ldspecs=-fuse-linker-plugin
@@ -187,9 +187,9 @@ teensy41.menu.opt.ogstd.build.flags.ldspecs=
 teensy41.menu.opt.osstd=Smallest Code
 teensy41.menu.opt.osstd.build.flags.optimize=-Os --specs=nano.specs
 teensy41.menu.opt.osstd.build.flags.ldspecs=
-#teensy41.menu.opt.oslto=Smallest Code with LTO
-#teensy41.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
-#teensy41.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
+teensy41.menu.opt.oslto=Smallest Code with LTO
+teensy41.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
+teensy41.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
 
 teensy41.menu.keys.en-us=US English
 teensy41.menu.keys.en-us.build.keylayout=US_ENGLISH
@@ -271,8 +271,8 @@ teensyMM.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensyMM.build.flags.dep=-MMD
 teensyMM.build.flags.optimize=-Os
 teensyMM.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensyMM.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=158
-teensyMM.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
+teensyMM.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=159
+teensyMM.build.flags.cpp=-std=gnu++17 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensyMM.build.flags.c=
 teensyMM.build.flags.S=-x assembler-with-cpp
 teensyMM.build.flags.libs=-larm_cortexM7lfsp_math -lm -lstdc++
@@ -387,24 +387,24 @@ teensyMM.menu.speed.24.build.fcpu=24000000
 teensyMM.menu.opt.o2std=Faster
 teensyMM.menu.opt.o2std.build.flags.optimize=-O2
 teensyMM.menu.opt.o2std.build.flags.ldspecs=
-#teensyMM.menu.opt.o2lto=Faster with LTO
-#teensyMM.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
-#teensyMM.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.o2lto=Faster with LTO
+teensyMM.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
+teensyMM.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
 teensyMM.menu.opt.o1std=Fast
 teensyMM.menu.opt.o1std.build.flags.optimize=-O1
 teensyMM.menu.opt.o1std.build.flags.ldspecs=
-#teensyMM.menu.opt.o1lto=Fast with LTO
-#teensyMM.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
-#teensyMM.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.o1lto=Fast with LTO
+teensyMM.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
+teensyMM.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
 teensyMM.menu.opt.o3std=Fastest
 teensyMM.menu.opt.o3std.build.flags.optimize=-O3
 teensyMM.menu.opt.o3std.build.flags.ldspecs=
 #teensyMM.menu.opt.o3purestd=Fastest + pure-code
 #teensyMM.menu.opt.o3purestd.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__
 #teensyMM.menu.opt.o3purestd.build.flags.ldspecs=
-#teensyMM.menu.opt.o3lto=Fastest with LTO
-#teensyMM.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
-#teensyMM.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.o3lto=Fastest with LTO
+teensyMM.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
+teensyMM.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
 #teensyMM.menu.opt.o3purelto=Fastest + pure-code with LTO
 #teensyMM.menu.opt.o3purelto.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__ -flto -fno-fat-lto-objects
 #teensyMM.menu.opt.o3purelto.build.flags.ldspecs=-fuse-linker-plugin
@@ -417,9 +417,9 @@ teensyMM.menu.opt.ogstd.build.flags.ldspecs=
 teensyMM.menu.opt.osstd=Smallest Code
 teensyMM.menu.opt.osstd.build.flags.optimize=-Os --specs=nano.specs
 teensyMM.menu.opt.osstd.build.flags.ldspecs=
-#teensyMM.menu.opt.oslto=Smallest Code with LTO
-#teensyMM.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
-#teensyMM.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
+teensyMM.menu.opt.oslto=Smallest Code with LTO
+teensyMM.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
+teensyMM.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
 
 teensyMM.menu.keys.en-us=US English
 teensyMM.menu.keys.en-us.build.keylayout=US_ENGLISH
@@ -501,8 +501,8 @@ teensy40.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy40.build.flags.dep=-MMD
 teensy40.build.flags.optimize=-Os
 teensy40.build.flags.cpu=-mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
-teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=158
-teensy40.build.flags.cpp=-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
+teensy40.build.flags.defs=-D__IMXRT1062__ -DTEENSYDUINO=159
+teensy40.build.flags.cpp=-std=gnu++17 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing
 teensy40.build.flags.c=
 teensy40.build.flags.S=-x assembler-with-cpp
 teensy40.build.flags.libs=-larm_cortexM7lfsp_math -lm -lstdc++
@@ -617,24 +617,24 @@ teensy40.menu.speed.24.build.fcpu=24000000
 teensy40.menu.opt.o2std=Faster
 teensy40.menu.opt.o2std.build.flags.optimize=-O2
 teensy40.menu.opt.o2std.build.flags.ldspecs=
-#teensy40.menu.opt.o2lto=Faster with LTO
-#teensy40.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
-#teensy40.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
+teensy40.menu.opt.o2lto=Faster with LTO
+teensy40.menu.opt.o2lto.build.flags.optimize=-O2 -flto -fno-fat-lto-objects
+teensy40.menu.opt.o2lto.build.flags.ldspecs=-fuse-linker-plugin
 teensy40.menu.opt.o1std=Fast
 teensy40.menu.opt.o1std.build.flags.optimize=-O1
 teensy40.menu.opt.o1std.build.flags.ldspecs=
-#teensy40.menu.opt.o1lto=Fast with LTO
-#teensy40.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
-#teensy40.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
+teensy40.menu.opt.o1lto=Fast with LTO
+teensy40.menu.opt.o1lto.build.flags.optimize=-O1 -flto -fno-fat-lto-objects
+teensy40.menu.opt.o1lto.build.flags.ldspecs=-fuse-linker-plugin
 teensy40.menu.opt.o3std=Fastest
 teensy40.menu.opt.o3std.build.flags.optimize=-O3
 teensy40.menu.opt.o3std.build.flags.ldspecs=
 #teensy40.menu.opt.o3purestd=Fastest + pure-code
 #teensy40.menu.opt.o3purestd.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__
 #teensy40.menu.opt.o3purestd.build.flags.ldspecs=
-#teensy40.menu.opt.o3lto=Fastest with LTO
-#teensy40.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
-#teensy40.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
+teensy40.menu.opt.o3lto=Fastest with LTO
+teensy40.menu.opt.o3lto.build.flags.optimize=-O3 -flto -fno-fat-lto-objects
+teensy40.menu.opt.o3lto.build.flags.ldspecs=-fuse-linker-plugin
 #teensy40.menu.opt.o3purelto=Fastest + pure-code with LTO
 #teensy40.menu.opt.o3purelto.build.flags.optimize=-O3 -mpure-code -D__PURE_CODE__ -flto -fno-fat-lto-objects
 #teensy40.menu.opt.o3purelto.build.flags.ldspecs=-fuse-linker-plugin
@@ -647,9 +647,9 @@ teensy40.menu.opt.ogstd.build.flags.ldspecs=
 teensy40.menu.opt.osstd=Smallest Code
 teensy40.menu.opt.osstd.build.flags.optimize=-Os --specs=nano.specs
 teensy40.menu.opt.osstd.build.flags.ldspecs=
-#teensy40.menu.opt.oslto=Smallest Code with LTO
-#teensy40.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
-#teensy40.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
+teensy40.menu.opt.oslto=Smallest Code with LTO
+teensy40.menu.opt.oslto.build.flags.optimize=-Os -flto -fno-fat-lto-objects --specs=nano.specs
+teensy40.menu.opt.oslto.build.flags.ldspecs=-fuse-linker-plugin
 
 teensy40.menu.keys.en-us=US English
 teensy40.menu.keys.en-us.build.keylayout=US_ENGLISH
@@ -727,8 +727,8 @@ teensy36.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy36.build.flags.dep=-MMD
 teensy36.build.flags.optimize=-Os
 teensy36.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=158
-teensy36.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
+teensy36.build.flags.defs=-D__MK66FX1M0__ -DTEENSYDUINO=159
+teensy36.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++17 -Wno-error=narrowing -fno-rtti
 teensy36.build.flags.c=
 teensy36.build.flags.S=-x assembler-with-cpp
 teensy36.build.flags.ld=-Wl,--gc-sections,--relax,--defsym=__rtc_localtime={extra.time.local} "-T{build.core.path}/mk66fx1m0.ld"
@@ -967,8 +967,8 @@ teensy35.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy35.build.flags.dep=-MMD
 teensy35.build.flags.optimize=-Os
 teensy35.build.flags.cpu=-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant
-teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=158
-teensy35.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
+teensy35.build.flags.defs=-D__MK64FX512__ -DTEENSYDUINO=159
+teensy35.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++17 -Wno-error=narrowing -fno-rtti
 teensy35.build.flags.c=
 teensy35.build.flags.S=-x assembler-with-cpp
 teensy35.build.flags.ld=-Wl,--gc-sections,--relax,--defsym=__rtc_localtime={extra.time.local} "-T{build.core.path}/mk64fx512.ld"
@@ -1198,8 +1198,8 @@ teensy31.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy31.build.flags.dep=-MMD
 teensy31.build.flags.optimize=-Os
 teensy31.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=158
-teensy31.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
+teensy31.build.flags.defs=-D__MK20DX256__ -DTEENSYDUINO=159
+teensy31.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++17 -Wno-error=narrowing -fno-rtti
 teensy31.build.flags.c=
 teensy31.build.flags.S=-x assembler-with-cpp
 teensy31.build.flags.ld=-Wl,--gc-sections,--relax,--defsym=__rtc_localtime={extra.time.local} "-T{build.core.path}/mk20dx256.ld"
@@ -1439,8 +1439,8 @@ teensy30.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdl
 teensy30.build.flags.dep=-MMD
 teensy30.build.flags.optimize=-Os
 teensy30.build.flags.cpu=-mthumb -mcpu=cortex-m4 -fsingle-precision-constant
-teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=158
-teensy30.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
+teensy30.build.flags.defs=-D__MK20DX128__ -DTEENSYDUINO=159
+teensy30.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++17 -Wno-error=narrowing -fno-rtti
 teensy30.build.flags.c=
 teensy30.build.flags.S=-x assembler-with-cpp
 teensy30.build.flags.ld=-Wl,--gc-sections,--relax,--defsym=__rtc_localtime={extra.time.local} "-T{build.core.path}/mk20dx128.ld"
@@ -1615,8 +1615,8 @@ teensyLC.build.command.size=arm-none-eabi-size
 teensyLC.build.flags.common=-g -Wall -ffunction-sections -fdata-sections -nostdlib -mno-unaligned-access
 teensyLC.build.flags.dep=-MMD
 teensyLC.build.flags.cpu=-mthumb -mcpu=cortex-m0plus -fsingle-precision-constant
-teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=158
-teensyLC.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti
+teensyLC.build.flags.defs=-D__MKL26Z64__ -DTEENSYDUINO=159
+teensyLC.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++17 -Wno-error=narrowing -fno-rtti
 teensyLC.build.flags.c=
 teensyLC.build.flags.S=-x assembler-with-cpp
 teensyLC.build.flags.ld=-Wl,--gc-sections,--relax,--defsym=__rtc_localtime={extra.time.local} "-T{build.core.path}/mkl26z64.ld"
@@ -1790,7 +1790,7 @@ teensypp2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensypp2.build.flags.dep=-MMD
 teensypp2.build.flags.optimize=-Os
 teensypp2.build.flags.cpu=-mmcu=at90usb1286
-teensypp2.build.flags.defs=-DTEENSYDUINO=158 -DARDUINO_ARCH_AVR
+teensypp2.build.flags.defs=-DTEENSYDUINO=159 -DARDUINO_ARCH_AVR
 teensypp2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensypp2.build.flags.c=
 teensypp2.build.flags.S=-x assembler-with-cpp
@@ -1918,7 +1918,7 @@ teensy2.build.flags.common=-g -Wall -ffunction-sections -fdata-sections
 teensy2.build.flags.dep=-MMD
 teensy2.build.flags.optimize=-Os
 teensy2.build.flags.cpu=-mmcu=atmega32u4
-teensy2.build.flags.defs=-DTEENSYDUINO=158 -DARDUINO_ARCH_AVR
+teensy2.build.flags.defs=-DTEENSYDUINO=159 -DARDUINO_ARCH_AVR
 teensy2.build.flags.cpp=-fno-exceptions -fpermissive -felide-constructors -std=gnu++11
 teensy2.build.flags.c=
 teensy2.build.flags.S=-x assembler-with-cpp

--- a/teensy/avr/cores/teensy3/WProgram.h
+++ b/teensy/avr/cores/teensy3/WProgram.h
@@ -51,6 +51,7 @@
 
 #ifdef __cplusplus
 
+#include "inplace_function.h"
 #include "avr_emulation.h"
 #include "usb_serial.h"
 #include "usb_serial2.h"

--- a/teensy/avr/cores/teensy3/usb_serial.h
+++ b/teensy/avr/cores/teensy3/usb_serial.h
@@ -155,7 +155,7 @@ public:
 	size_t write(long n) { return 1; }
 	size_t write(unsigned int n) { return 1; }
 	size_t write(int n) { return 1; }
-	int availableForWrite() { return 0; }
+	virtual int availableForWrite() { return 0; }
 	using Print::write;
         void send_now(void) { }
         uint32_t baud(void) { return 0; }

--- a/teensy/avr/cores/teensy4/WProgram.h
+++ b/teensy/avr/cores/teensy4/WProgram.h
@@ -48,6 +48,7 @@
 
 #ifdef __cplusplus
 
+#include "inplace_function.h"
 #include "avr_emulation.h"
 #include "usb_serial.h"
 #include "usb_seremu.h"

--- a/teensy/avr/cores/teensy4/usb.c
+++ b/teensy/avr/cores/teensy4/usb.c
@@ -209,7 +209,7 @@ FLASHMEM void usb_init(void)
 }
 
 
-FLASHMEM void _reboot_Teensyduino_(void)
+FLASHMEM __attribute__((noinline)) void _reboot_Teensyduino_(void)
 {
 	if (!(HW_OCOTP_CFG5 & 0x02)) {
 		asm("bkpt #251"); // run bootloader
@@ -677,6 +677,19 @@ static void endpoint0_setup(uint64_t setupdata)
 			endpoint0_buffer[1] = 44100 >> 8;
 			endpoint0_buffer[2] = 0;
 			endpoint0_transmit(endpoint0_buffer, 3, 0);
+			return;
+		}
+		break;
+#endif
+#if defined(MULTITOUCH_INTERFACE)
+	  case 0x01A1:
+		if (setup.wValue == 0x0300 && setup.wIndex == MULTITOUCH_INTERFACE) {
+			endpoint0_buffer[0] = MULTITOUCH_FINGERS;
+			endpoint0_transmit(endpoint0_buffer, 1, 0);
+			return;
+		} else if (setup.wValue == 0x0100 && setup.wIndex == MULTITOUCH_INTERFACE) {
+			memset(endpoint0_buffer, 0, 8);
+			endpoint0_transmit(endpoint0_buffer, 8, 0);
 			return;
 		}
 		break;

--- a/teensy/avr/cores/teensy4/usb_serial.h
+++ b/teensy/avr/cores/teensy4/usb_serial.h
@@ -58,6 +58,7 @@ extern volatile uint32_t systick_millis_count;
 extern volatile uint8_t usb_cdc_line_rtsdtr;
 extern volatile uint8_t usb_cdc_transmit_flush_timer;
 extern volatile uint8_t usb_configuration;
+extern void serialEvent(void) __attribute__((weak));
 #ifdef __cplusplus
 }
 #endif
@@ -185,7 +186,6 @@ public:
 };
 // Serial provides USB Virtual Serial communication with your computer.
 extern usb_serial_class Serial;
-extern void serialEvent(void);
 #endif // __cplusplus
 
 #else  // !defined(USB_DISABLED)
@@ -210,7 +210,7 @@ public:
     size_t write(long n) { return 1; }
     size_t write(unsigned int n) { return 1; }
     size_t write(int n) { return 1; }
-    int availableForWrite() { return 0; }
+    virtual int availableForWrite() { return 0; }
     using Print::write;
         void send_now(void) { }
         uint32_t baud(void) { return 0; }
@@ -223,7 +223,6 @@ public:
 };
 
 extern usb_serial_class Serial;
-extern void serialEvent(void);
 #endif // __cplusplus
 
 #endif // !defined(USB_DISABLED)
@@ -253,6 +252,7 @@ extern uint32_t usb_cdc2_line_coding[2];
 extern volatile uint32_t usb_cdc2_line_rtsdtr_millis;
 extern volatile uint8_t usb_cdc2_line_rtsdtr;
 extern volatile uint8_t usb_cdc2_transmit_flush_timer;
+extern void serialEventUSB1(void) __attribute__((weak));
 #ifdef __cplusplus
 }
 #endif
@@ -316,7 +316,6 @@ public:
 
 };
 extern usb_serial2_class SerialUSB1;
-extern void serialEventUSB1(void);
 #endif // __cplusplus
 
 #endif // CDC2_STATUS_INTERFACE && CDC2_DATA_INTERFACE
@@ -343,6 +342,7 @@ extern uint32_t usb_cdc3_line_coding[2];
 extern volatile uint32_t usb_cdc3_line_rtsdtr_millis;
 extern volatile uint8_t usb_cdc3_line_rtsdtr;
 extern volatile uint8_t usb_cdc3_transmit_flush_timer;
+extern void serialEventUSB2(void) __attribute__((weak));
 #ifdef __cplusplus
 }
 #endif
@@ -406,7 +406,6 @@ public:
 
 };
 extern usb_serial3_class SerialUSB2;
-extern void serialEventUSB2(void);
 #endif // __cplusplus
 
 #endif // CDC3_STATUS_INTERFACE && CDC3_DATA_INTERFACE

--- a/teensy/avr/cores/teensy4/usb_serial.h
+++ b/teensy/avr/cores/teensy4/usb_serial.h
@@ -186,6 +186,7 @@ public:
 };
 // Serial provides USB Virtual Serial communication with your computer.
 extern usb_serial_class Serial;
+extern void serialEvent(void) __attribute__((weak));
 #endif // __cplusplus
 
 #else  // !defined(USB_DISABLED)

--- a/teensy/avr/cores/teensy4/usb_serial.h
+++ b/teensy/avr/cores/teensy4/usb_serial.h
@@ -186,7 +186,6 @@ public:
 };
 // Serial provides USB Virtual Serial communication with your computer.
 extern usb_serial_class Serial;
-extern void serialEvent(void) __attribute__((weak));
 #endif // __cplusplus
 
 #else  // !defined(USB_DISABLED)
@@ -224,6 +223,7 @@ public:
 };
 
 extern usb_serial_class Serial;
+extern void serialEvent(void) __attribute__((weak));
 #endif // __cplusplus
 
 #endif // !defined(USB_DISABLED)


### PR DESCRIPTION
Updates core files for compatibility with Teensyduino 1.59.

This PR also makes some minor changes to the continuous integration script, updating a deprecated dependency and changing the behavior of the matrix strategy fail-fast option.